### PR TITLE
Update GitHub org references for affected repositories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title: Login.gov
 description: Welcome to the Login.gov developer documentation!
-github_repo_url: https://github.com/18F/identity-dev-docs # enables "edit this page" button
+github_repo_url: https://github.com/GSA-TTS/identity-dev-docs # enables "edit this page" button
 url: https://developers.login.gov
 
 # temporary_alert: "The Login.gov sandbox (<b>not production</b>) will be unavailable from <b>5-6p ET on Tuesday, January 31st, 2023</b> for maintenance."
@@ -58,6 +58,6 @@ keep_files:
 # Defaults
 defaults:
   - scope:
-      path: ""
+      path: ''
     values:
       layout: documentation

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,4 +1,4 @@
-<!-- borrowed heavily from https://github.com/18F/identity-site/blob/main/_includes/search.html -->
+<!-- borrowed heavily from https://github.com/GSA-TTS/identity-site/blob/main/_includes/search.html -->
 <form
   accept-charset="UTF-8"
   action="https://search.usa.gov/search"
@@ -8,9 +8,21 @@
   role="search"
 >
   <input name="utf8" type="hidden" value="&#x2713;" />
-  <input type="hidden" name="affiliate" id="affiliate" value="developers-login-gov" autocomplete="off" />
+  <input
+    type="hidden"
+    name="affiliate"
+    id="affiliate"
+    value="developers-login-gov"
+    autocomplete="off"
+  />
   <label class="usa-sr-only" for="search-field-{{ include.id }}">Search</label>
-  <input type="search" name="query" id="search-field-{{ include.id }}" autocomplete="off" class="usa-input" />
+  <input
+    type="search"
+    name="query"
+    id="search-field-{{ include.id }}"
+    autocomplete="off"
+    class="usa-input"
+  />
   <button class="usa-button" type="submit" name="commit" value="Search" data-disable-with="Search">
     <span class="usa-search__submit-text">Search</span>
   </button>

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/18F/identity-dev-docs.git"
+    "url": "git+https://github.com/GSA-TTS/identity-dev-docs.git"
   },
   "license": "CC0-1.0",
   "bugs": {
-    "url": "https://github.com/18F/identity-dev-docs/issues"
+    "url": "https://github.com/GSA-TTS/identity-dev-docs/issues"
   },
-  "homepage": "https://github.com/18F/identity-dev-docs#readme",
+  "homepage": "https://github.com/GSA-TTS/identity-dev-docs#readme",
   "dependencies": {
     "@18f/identity-build-sass": "^3.0.0",
     "@18f/identity-design-system": "^8.1.2"

--- a/scripts/htmlproofer
+++ b/scripts/htmlproofer
@@ -5,7 +5,7 @@ require 'html-proofer'
 require 'optparse'
 require 'jekyll'
 
-proofer_options = { ignore_urls: [%r{\Ahttps://github.com/18F/identity-dev-docs/edit}] }
+proofer_options = { ignore_urls: [%r{\Ahttps://github.com/GSA-TTS/identity-dev-docs/edit}] }
 OptionParser.new do |opt|
   opt.on('--internal') { proofer_options[:disable_external] = true }
   opt.on('--external') { proofer_options[:external_only] = true }


### PR DESCRIPTION
## 🛠 Summary of changes

Updates references to the previous 18F GitHub organization for sites migrated to the GSA-TTS organization.