### PR TITLE
Updates x509 attribute types

### DIFF
--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -290,10 +290,10 @@ n/a
 <td markdown="1">
 `x509_issuer` (string)
 
-Requires the `x509:issuer` scope.
+Requires the `x509:issuer` or `x509` scope.
 </td>
 <td markdown="1">
-`x509_issuer`
+`x509_issuer` (string)
 </td>
     </tr>
     <tr>
@@ -309,10 +309,10 @@ Requires the `x509:issuer` scope.
 <td markdown="1">
 `x509_subject` (string)
 
-Requires the `x509:subject` scope.
+Requires the `x509:subject` or `x509` scope.
 </td>
 <td markdown="1">
-`x509_subject`
+`x509_subject` (string)
 </td>
     </tr>
     <tr>
@@ -326,12 +326,12 @@ Requires the `x509:subject` scope.
 {{ checkmark }}
 </td>
 <td markdown="1">
-`x509_presented` (string)
+`x509_presented` (boolean)
 
-Requires the `x509:presented` scope.
+Requires the `x509:presented` or `x509` scope.
 </td>
 <td markdown="1">
-`x509_presented`
+`x509_presented` (string)
 </td>
     </tr>
   </tbody>


### PR DESCRIPTION
As part of fixing the x509_attributes bug, https://github.com/18F/identity-idp/pull/10239, we decided to update the x509_presented attribute to a `boolean`. This is updating the documentation to our expected return value.