### PR TITLE
LG-12103 Update embed code for lookbook sign in button component

### DIFF
--- a/_pages/user-experience/sign-in-sign-out.md
+++ b/_pages/user-experience/sign-in-sign-out.md
@@ -94,7 +94,7 @@ Do use the white button with an outline on light backgrounds that don’t provid
 </ul>
 
 <div class="lookbook-embed-container margin-top-4">
-<iframe class="lookbook-embed" src="https://idp.dev.identitysandbox.gov/components/embed/login_button/workbench?_options=%257B%2522scenarios%2522%253A%255B%2522workbench%2522%255D%252C%2522panels%2522%253A%255B%2522params%2522%252C%2522%2522%255D%257D"></iframe>
+<iframe class="lookbook-embed" src="https://idp.dev.identitysandbox.gov/components/embed/login_button/workbench?_options=%257B%2522scenarios%2522%253A%255B%2522workbench%2522%255D%252C%2522panels%2522%253A%255B%2522params%2522%252C%2522output%2522%255D%257D"></iframe>
 </div>
 
 ### Login.gov logos


### PR DESCRIPTION
Related to[ this PR was merged](https://github.com/18F/identity-idp/pull/10387) this morning that updates the lookbook component so that it has embedded styles that the partner can copy and paste ( not just the HTML )

Ticket: https://cm-jira.usa.gov/browse/LG-12103?filter=-1

This just updates the embed code to include the HTML (output) panel

NOTE: the build will not display the embed code properly, please visit 

https://idp.dev.identitysandbox.gov/components/embed/login_button/workbench?_options=%257B%2522scenarios%2522%253A%255B%2522workbench%2522%255D%252C%2522panels%2522%253A%255B%2522params%2522%252C%2522output%2522%255D%257D&big=true

to see what the embed would look like 

