### PR TITLE
LG-12538 Update footnotes on OIDC page from `1` to `*`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 test: build
 	bundle exec rspec spec
-	node --test spec/e2e/
+	node --test spec/e2e/**
 
 htmlproofer:
 	bundle exec scripts/htmlproofer

--- a/_includes/snippets/auth_content/service_levels.md
+++ b/_includes/snippets/auth_content/service_levels.md
@@ -1,10 +1,10 @@
 {% capture type_of_service %}
-  A type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> must be specified.
+  A type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">&#42;</a></sup> must be specified.
 
 - **`http://idmanagement.gov/ns/assurance/ial/1`**
     Basic identity assurance, does not require identity verification (this is the most common value).
 - **`http://idmanagement.gov/ns/assurance/ial/2`**
-    Requires that the user has gone through identity verification<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup>
+    Requires that the user has gone through identity verification<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">&#42;</a></sup>
 {% endcapture %}
 <div markdown="1">
 {{ type_of_service | markdownify }}

--- a/_includes/snippets/auth_content/service_levels.md
+++ b/_includes/snippets/auth_content/service_levels.md
@@ -1,10 +1,10 @@
 {% capture type_of_service %}
-  A type of service level<sup id="fnref:1:2" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> must be specified.
+  A type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> must be specified.
 
 - **`http://idmanagement.gov/ns/assurance/ial/1`**
     Basic identity assurance, does not require identity verification (this is the most common value).
 - **`http://idmanagement.gov/ns/assurance/ial/2`**
-    Requires that the user has gone through identity verification<sup id="fnref:1:3" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup>
+    Requires that the user has gone through identity verification<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup>
 {% endcapture %}
 <div markdown="1">
 {{ type_of_service | markdownify }}

--- a/_includes/snippets/auth_content/service_levels.md
+++ b/_includes/snippets/auth_content/service_levels.md
@@ -1,10 +1,10 @@
 {% capture type_of_service %}
-  A type of service level<sup id="fnref:1:2" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">1</a></sup> must be specified.
+  A type of service level<sup id="fnref:1:2" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> must be specified.
 
 - **`http://idmanagement.gov/ns/assurance/ial/1`**
     Basic identity assurance, does not require identity verification (this is the most common value).
 - **`http://idmanagement.gov/ns/assurance/ial/2`**
-    Requires that the user has gone through identity verification<sup id="fnref:1:3" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">1</a></sup>
+    Requires that the user has gone through identity verification<sup id="fnref:1:3" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup>
 {% endcapture %}
 <div markdown="1">
 {{ type_of_service | markdownify }}

--- a/_pages/oidc/authorization.md
+++ b/_pages/oidc/authorization.md
@@ -119,7 +119,7 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
       <h4 id="acr_values" class="parameters">acr_values</h4>
     </div>
     <div class="grid-col-7">
-        The Authentication Context Class Reference requests can be used to specify the type of service level<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">1</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
+        The Authentication Context Class Reference requests can be used to specify the type of service level<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
       <p>
         Multiple values can be joined with a space (before being URI-escaped in the final URL).
       </p>
@@ -131,10 +131,6 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
         {% include accordion.html content=aal_values accordion_id="aal_accordion" title="Authentication Assurance (AAL) Values" id="aal_values" %}
         {% include accordion.html content=loa_values accordion_id="loa_accordion" title="Level of Assurance (LOA) Values (Deprecated)" id="loa_values" %}
       </div>
-      <p id="fn:1">
-        1. Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization.
-        <a href="#fnref:1">↩</a>1 <a href="#fnref:1:2">↩</a>2 <a href="#fnref:1:3">↩</a>3
-      </p>
     </div>
     <div class="grid-row dev-doc-row">
       <div class="grid-col-5">
@@ -272,6 +268,11 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
         {% include snippets/oidc/auth/failure.md %}
       </section>
     </div>
+  </div>
+  <div class="desktop:grid-col-9 mobile:grid-col-full">
+    <p id="fn:1">
+      *Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization.
+    </p>
   </div>
   <a href="{{ '/oidc/token/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Token</a>
 </div>

--- a/_pages/oidc/authorization.md
+++ b/_pages/oidc/authorization.md
@@ -119,7 +119,7 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
       <h4 id="acr_values" class="parameters">acr_values</h4>
     </div>
     <div class="grid-col-7">
-        The Authentication Context Class Reference requests can be used to specify the type of service level<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
+        The Authentication Context Class Reference requests can be used to specify the type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
       <p>
         Multiple values can be joined with a space (before being URI-escaped in the final URL).
       </p>

--- a/_pages/oidc/authorization.md
+++ b/_pages/oidc/authorization.md
@@ -119,7 +119,7 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
       <h4 id="acr_values" class="parameters">acr_values</h4>
     </div>
     <div class="grid-col-7">
-        The Authentication Context Class Reference requests can be used to specify the type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">*</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
+        The Authentication Context Class Reference requests can be used to specify the type of service level<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">&#42;</a></sup> or the AAL (Authentication Assurance Level) for the user. These and the <code class="language-plaintext highlighter-rouge">scope</code> determine which <a class="usa-link" href="{{ '/attributes/' | prepend: site.baseurl }}">user attributes</a> will be available in the <a class="usa-link" href="{{ '/oidc/user-info/#user-info-response' | prepend: site.baseurl }}">user info response</a>.
       <p>
         Multiple values can be joined with a space (before being URI-escaped in the final URL).
       </p>
@@ -270,9 +270,7 @@ In an **unsuccessful authorization**, the URI will contain the parameters `error
     </div>
   </div>
   <div class="desktop:grid-col-9 mobile:grid-col-full">
-    <p id="fn:1">
-      *Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization.
-    </p>
+    <p id="fn:1" role="doc-endnote">&#42;Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization.</p>
   </div>
   <a href="{{ '/oidc/token/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Token</a>
 </div>

--- a/_pages/saml/authentication.md
+++ b/_pages/saml/authentication.md
@@ -31,7 +31,7 @@ sidenav:
 `<samlp:AuthnRequest>:SAML_REQUEST = urlEncode(base64(deflate(payload)))`
 {% endcapture %}
 {% capture saml_tag %}
-The `<saml:AuthnContextClassRef>` tags (nested under `//samlp:AuthnRequest/samlp:RequestedAuthnContext/`) specify the type of identity verification<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">1</a></sup>, AAL (Authentication Assurance Level) and attributes requested.
+The `<saml:AuthnContextClassRef>` tags (nested under `//samlp:AuthnRequest/samlp:RequestedAuthnContext/`) specify the type of identity verification<sup role="doc-noteref"><a href="#fn:1" class="footnote" rel="footnote">&#42;</a></sup>, AAL (Authentication Assurance Level) and attributes requested.
 {% endcapture %}
 {% capture attributes %}
 To request specific attributes, list them (comma-separated) as the query parameter for `http://idmanagement.gov/ns/requested_attributes?ReqAttr=`. See the [user attributes]({{ '/attributes/' | prepend: site.baseurl }}) for the list of attributes that can be requested.
@@ -73,13 +73,6 @@ A proofed identity request at AAL3 for email, phone, first name, last name, and 
                 {% include accordion.html content=aal_values accordion_id="aal_accordion" title="Authentication Assurance (AAL) Values" id="aal_values" %}
                 {% include accordion.html content=attributes accordion_id="attributes_accordion" title="Attributes" id="attributes" %}
                 {% include accordion.html content=loa_values accordion_id="loa_accordion" title="Level of Assurance (LOA) Values (Deprecated)" id="loa_values" %}
-            </div>
-            <div class="footnotes" role="doc-endnotes">
-                <ol>
-                    <li id="fn:1" role="doc-endnote">
-                    Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization. <a href="./#fnref:1" class="reversefootnote" aria-label="Back to content 1" role="doc-backlink">&#8617;<sup>1</sup></a> <a href="#fnref:1:2" class="reversefootnote" aria-label="Back to content 2" role="doc-backlink">&#8617;<sup>2</sup></a>
-                    </li>
-                </ol>
             </div>
         </div>
         <div class="dev-doc-row">
@@ -137,7 +130,10 @@ A proofed identity request at AAL3 for email, phone, first name, last name, and 
             </section>
         </section>
     </div>
-      <a href="{{ '/saml/logout/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Logout</a>
+    <div class="desktop:grid-col-7 mobile:grid-col-full" role="doc-endnotes">
+        <p id="fn:1" role="doc-endnote">&#42;Login.gov continues to work toward achieving certification of compliance with NIST’s IAL2 standard from a third-party assessment organization.</p>
+    </div>
+    <a href="{{ '/saml/logout/' | prepend: site.baseurl }}" class="usa-link mobile:display-block desktop:display-none margin-top-2">Next step: Logout</a>
 </div>
 
 


### PR DESCRIPTION
The footnote links on [OIDC/Auth](https://developers.login.gov/oidc/authorization) only work properly when the accordion section that they link to is open.
This PR updates the links to be one-way, from the text to the footnote, rather than also including the reverse direction back to the text.

I've removed the now-superfluous `id`s on the links, and updated E2E tests to include the `**` glob (it was trying to run the folder, and I was getting a failing error).