### PR TITLE
Update sample PII in test documents to match results of `pii_from_doc` in the IdP

### DIFF
--- a/assets/yaml/individual_state_error.yml
+++ b/assets/yaml/individual_state_error.yml
@@ -1,5 +1,4 @@
 document:
-  type: license
   first_name: Susan
   last_name: Smith
   middle_name: Q
@@ -8,8 +7,11 @@ document:
   city: Bayside
   state: NY
   zipcode: '11364'
-  dob: 10/06/1938
+  dob: '1938-10-06'
   phone: +1 314-555-1212
   state_id_number: "mvatimeout"
   state_id_type: "drivers_license"
   state_id_jurisdiction: "WA"
+  state_id_expiration: '2030-01-01'
+  state_id_issued: '2020-01-01'
+  issuing_country_code: 'US'

--- a/assets/yaml/proofing.yml
+++ b/assets/yaml/proofing.yml
@@ -1,5 +1,4 @@
 document:
-  type: license
   first_name: Susan
   last_name: Smith
   middle_name: Q
@@ -8,8 +7,11 @@ document:
   city: Bayside
   state: NY
   zipcode: '11364'
-  dob: 10/06/1938
+  dob: '1938-10-06'
   phone: +1 314-555-1212
   state_id_number: '123456789'
   state_id_type: drivers_license
   state_id_jurisdiction: 'NY'
+  state_id_expiration: '2030-01-01'
+  state_id_issued: '2020-01-01'
+  issuing_country_code: 'US'

--- a/assets/yaml/proofing_vendor_error.yml
+++ b/assets/yaml/proofing_vendor_error.yml
@@ -1,5 +1,4 @@
 document:
-  type: license
   first_name: Parse
   last_name: Smith
   middle_name: Q
@@ -8,8 +7,11 @@ document:
   city: Bayside
   state: WA
   zipcode: '99237'
-  dob: 10/06/2000
+  dob: '1938-10-06'
   phone: +1 206-555-1212
   state_id_number: '123456789'
   state_id_type: drivers_license
   state_id_jurisdiction: 'WA'
+  state_id_expiration: '2030-01-01'
+  state_id_issued: '2020-01-01'
+  issuing_country_code: 'US'


### PR DESCRIPTION
The `DocAuthMockClient` returns the value under the `document` key in the YAML test values ([ref](https://github.com/18F/identity-idp/blob/c53dce8f6679d25d29ba9a7d71911a58c0748f12/app/services/doc_auth/mock/result_response.rb#L83)).

This commit changes the value under this key in the sample YAML documents to match what is returned by the actual doc auth client. That was done by referencing the `DocAuth::LexisNexis::DocPiiReader` which is used to read the PII from the response and construct the `pii_from_doc` response for the TrueID client ([ref](https://github.com/18F/identity-idp/blob/c53dce8f6679d25d29ba9a7d71911a58c0748f12/app/services/doc_auth/lexis_nexis/doc_pii_reader.rb)).