### PR TITLE
Change the URL to go to the doc page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -17,7 +17,7 @@ layout: home
     <ol class="usa-process-list usa-prose margin-bottom-4">
       <li class="usa-process-list__item">
         <p>
-          Your integration with Login.gov starts in the <a href="https://developers.login.gov/testing/#using-the-sandbox" class="usa-link">dashboard</a> where you can register your app.
+          Your integration with Login.gov starts in the <a href="{{ site.baseurl }}/testing/#using-the-sandbox" class="usa-link">dashboard</a> where you can register your app.
         </p>
       </li>
       <li class="usa-process-list__item">

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -17,7 +17,7 @@ layout: home
     <ol class="usa-process-list usa-prose margin-bottom-4">
       <li class="usa-process-list__item">
         <p>
-          Your integration with Login.gov starts in the <a href="https://dashboard.int.identitysandbox.gov/" class="usa-link">dashboard</a> where you can register your app.
+          Your integration with Login.gov starts in the <a href="https://developers.login.gov/testing/#using-the-sandbox" class="usa-link">dashboard</a> where you can register your app.
         </p>
       </li>
       <li class="usa-process-list__item">


### PR DESCRIPTION
### Ticket

[LG-12789](https://cm-jira.usa.gov/browse/LG-12789)

### Description of Changes

Change the `dashboard` link on the welcome page of the dev docs to link to the `Using The Sandbox` section of the `Testing` page instead of directly to the sandbox.