### PR TITLE
Add more detail to the JWT description

### DIFF
--- a/_pages/oidc/token.md
+++ b/_pages/oidc/token.md
@@ -23,7 +23,7 @@ sidenav:
 
 ---
 {% capture client_assertion %}
-A [JWT](https://jwt.io/){:class="usa-link--external"} signed with the client’s private key (minimum length of 2048 bits) using the RS256 algorithm and containing the following claims:
+A [JWT](https://jwt.io/){:class="usa-link--external"} signed with the client’s private key (minimum length of 2048 bits) associated with the public key uploaded to your application configuration within the Dashboard. The JWT should use the RS256 algorithm and containing the following claims:
 - **iss** (string) — The issuer, which must be the `client_id`.
 - **sub** (string) — The subject, which must also be the `client_id`.
 - **aud** (string) — The audience, which should be (or, in the case of multiple audience values, include) the URL of the token endpoint, for example: `https://idp.int.identitysandbox.gov/api/openid_connect/token`


### PR DESCRIPTION
A partner contacted us wanting clarification about the JWT in the token endpoint and how we validate it. This drew attention to the fact that our docs don't specify this info (that the private key should be associated with the public key uploaded to the dashboard) 

Ticket in Zendesk: https://logingov.zendesk.com/agent/tickets/9715

