### PR TITLE
Patch Circleci Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     docker:
       # Specify the Ruby version you desire here
-      - image: cimg/ruby:3.2-browsers
+      - image: cimg/ruby:3.2.5-browsers
     environment:
       BUNDLE_JOBS: '3'
       BUNDLE_RETRY: '3'


### PR DESCRIPTION
We were getting an error in Circle Ci about a Ruby version mismatch. This specifies a patch version so CircleCi doesn't use the latest version and cause a mismatch.

https://gsa-tts.slack.com/archives/C04RGFTFD70/p1730398127023439