### PR TITLE
Fix payload structure of account disabled event

### DIFF
--- a/_data/risc_outgoing.yml
+++ b/_data/risc_outgoing.yml
@@ -55,10 +55,10 @@
           type: string
           description: >
             The UUID identifying the user. This is the same as the `sub` inside the `id_token` JWT in the OpenID Token endpoint.
-        - key: reason
-          type: string
-          description: >
-            Optional, describes why was the account disabled..
+    - key: reason
+      type: string
+      description: >
+        Optional, describes why was the account disabled.
   example_payload: {
     "https://schemas.openid.net/secevent/risc/event-type/account-disabled": {
       "subject": {


### PR DESCRIPTION
The `reason` key is outside of the `subject`, and the example payload is correct, but the documentation currently has it inside. This PR also removes the extra period.

IDP for reference:
https://github.com/18F/identity-idp/blob/74f0ff081fb96eb02bb4f2665a01c7648f114f11/app/services/push_notification/account_disabled_event.rb#L18-L27
| Before                       | After                                                                         |
|-----------------------------|-------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/e7c0c332-23ba-4766-8ca3-37fb0a82d840) | ![image](https://github.com/user-attachments/assets/8c631fd8-56ef-4c90-82b5-5a07e5c27c08) |



