### PR TITLE
Add "kid" header to Security Event documentation

### DIFF
--- a/_pages/security-events.md
+++ b/_pages/security-events.md
@@ -323,6 +323,9 @@ s41MmdQzalGuKMX3Hr7Rn5xtnmJiQ5HQ7pcdCh5ZidWvw7VcblStN-rTLEBCUUO14pCfdAzVCs09Wb1W
 * **typ** (string)
   The type header will be set to **secevent+jwt**
 
+* **kid** (string)
+  The kid header will be the kid for one of the keys specified in the [Certificates Endpoint](/oidc/certificates/).
+
 #### JWT Claims
 
 * **aud** (string)


### PR DESCRIPTION
Based on questions received from a partner being discussed [here](https://gsa-tts.slack.com/archives/C01SU3NB9T3/p1734456442288269), this PR adds the `kid` header to the documentation for Security Events. We include this header in outgoing events in the identity-idp code [here](https://github.com/18F/identity-idp/blob/7ad5a8f/app/services/push_notification/http_push.rb#L68).