### PR TITLE
Document the new `locale` scope

### DIFF
--- a/_includes/snippets/oidc/user-info/response.md
+++ b/_includes/snippets/oidc/user-info/response.md
@@ -12,6 +12,7 @@
   "email": "test@example.com",
   "email_verified": true,
   "all_emails": ["test@example.com", "test2@example.com"],
+  "locale": "en",
   "family_name": "Smith",
   "given_name": "John",
   "iss": "https://idp.int.identitysandbox.gov",

--- a/_pages/attributes.md
+++ b/_pages/attributes.md
@@ -1,7 +1,7 @@
 ---
 title: User attributes
 lead: >
-  Login.gov user accounts are either identity proofed or self-asserted. 
+  Login.gov user accounts are either identity proofed or self-asserted.
 ---
 
 Here are the possible attributes that can be requested at a given IAL. This table contains the available user attributes, the IAL they are associated with, and how they can be accessed in OpenID Connect (OIDC) and SAML.
@@ -77,6 +77,23 @@ Requires the `email` scope.
 </td>
 <td markdown="1">
 `all_emails` (array of strings)
+</td>
+    </tr>
+    <tr>
+<td markdown="1">
+**Locale**<br />The user's language preference.
+</td>
+<td>
+{{ checkmark }}
+</td>
+<td>
+{{ checkmark }}
+</td>
+<td markdown="1">
+`locale` (string, ISO 639-1 language code)
+</td>
+<td markdown="1">
+`locale` (string, ISO 639-1 language code)
 </td>
     </tr>
     <tr>

--- a/_pages/oidc/authorization.md
+++ b/_pages/oidc/authorization.md
@@ -38,6 +38,7 @@ Possible values are:
    - `address`
    - `email`
    - `all_emails`
+   - `locale`
    - `phone`
    - `profile:birthdate`
    - `profile:name`

--- a/_pages/oidc/authorization/pkce.md
+++ b/_pages/oidc/authorization/pkce.md
@@ -59,6 +59,7 @@ Possible values are:
    - `address`
    - `email`
    - `all_emails`
+   - `locale`
    - `phone`
    - `profile:birthdate`
    - `profile:name`


### PR DESCRIPTION
In https://github.com/18F/identity-idp/pull/11756 we added a feature that allows service providers to request a user's locale and receive it in the claims about the user. This commit documents the mechanism that service providers should use to make that request with OIDC and SAML.