### PR TITLE
Update anchorjs icon

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Login.gov
-description: Welcome to the Login.gov developer documentation!
+description: Welcome to the Login.gov Developer Guide
 github_repo_url: https://github.com/GSA-TTS/identity-dev-docs # enables "edit this page" button
 url: https://developers.login.gov
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -156,6 +156,9 @@
     <script src="{{ site.baseurl }}/assets/js/anchor_accordion.js"></script>
 
     <script>
+      anchors.options = {
+        icon: '#'
+      };
       anchors.add([
         '#main-content h1:not(.usa-accordion__heading)',
         '#main-content h2:not(.usa-accordion__heading)',

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -1,5 +1,5 @@
 ---
-title: Welcome to the Login.gov developer guide
+title: Welcome to the Login.gov Developer Guide
 lead: >
   This developer guide contains everything you’ll need to integrate and deploy your application with Login.gov.
 permalink: /


### PR DESCRIPTION
We added some new anchors on the accordions that were `#`, which did not match the default anchorjs icons. This change updates the anchorjs icons to match the accordions, as that is the easiest way to make them consistent.


before:
<img width="650" height="141" alt="anchor tag with a chain link icon" src="https://github.com/user-attachments/assets/78451fc9-f6b5-457b-9172-3026e8312dbc" />

after:
<img width="643" height="150" alt="anchor tag with a # symbol" src="https://github.com/user-attachments/assets/0e9cb4f2-f0a0-4f22-8b95-856838dea522" />


I also updated some capitalization in the title, which can be seen if you hover over the favicon or in a link snippet

before:
<img width="277" height="89" alt="titles that says Welcome to the Login.gov developer guide (with developer guide not capitalized)" src="https://github.com/user-attachments/assets/087d131e-0802-499a-aa95-2b1e46eca6bf" />

after:
<img width="282" height="96" alt="title that says Welcome to the Login.gov Developer Guide (with developer guide capitalized)" src="https://github.com/user-attachments/assets/0d93536d-3000-4a87-96ca-5c879c34eea1" />
