### PR TITLE
Portal #130 partner integration checklist

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -28,7 +28,7 @@ sidenav:
     <li class="usa-process-list__item">
       <h3>Configure your application in the portal and start testing</h3>
       <p>
-        Utilize our <a class="usa-link" href="#integration-info-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
+        Utilize our <a class="usa-link" href="#integration-info-checklist" aria-label="anchor">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
       </p>
     </li>
     <li class="usa-process-list__item">
@@ -43,8 +43,8 @@ sidenav:
 <section class="margin-top-3 margin-bottom-4">
   <h2 id="integration-info-checklist">Integration information checklist</h2>
   <div id="home-register-checklist-accordion" class="usa-accordion usa-accordion__heading usa-accordion--bordered margin-bottom-3 maxw-tablet">
-    <button class="usa-accordion__button padding-y-1" aria-expanded="true" aria-controls="home-register-checklist">
-      <h3 class="font-body-md text-normal line-height-sans-1">Information you need to register your application</h3>
+    <button class="usa-accordion__button" aria-expanded="true" aria-controls="home-register-checklist">
+      Information you need to register your application
     </button>
     <div id="home-register-checklist" class="usa-accordion__content">
       <ul class="usa-list list-style-checkbox">

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -53,7 +53,7 @@ sidenav:
         <li>Implementation protocols (SAML or Open ID Connect)</li>
         <li>Service level as either Authentication only or Identity Verification</li>
         <li>Data you need to keep and collect and other <a class="usa-link" href="{% link _pages/attributes.md %}">user attributes</a></li>
-        <li><a class="usa-link" href="{% link _pages/oidc/authorization.md %}">Authentication assurance</a> levels</li>
+        <li><a class="usa-link" href="{% link _pages/oidc/authorization.md %}#aal_values">Authentication assurance</a> levels</li>
         <li>Agency logo file</li>
         <li>A public/private key pair and the <a class="usa-link" href="{% link _pages/testing.md %}#creating-a-public-certificate">public certificate</a> to validate your website and application’s authenticity</li>
         <li>Content for the “sign up”, “sign in”, and “forgot password” language if you do not want to use the pre-selected options. Custom “Help” text is optional.</li>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -16,48 +16,51 @@ sidenav:
       {% include alert.html content=site.temporary_alert %}
   </section>
 {% endif %}
-<h2 id="how-to-integrate-login">How to integrate with Login.gov</h2>
-<br/>
-<ol class="usa-process-list usa-prose margin-bottom-4">
-  <li class="usa-process-list__item">
-    <h3>Register your application in our partner portal</h3>
-    <p>
-      First, create a team. Then, follow the steps to create an application in a sandbox environment where you can configure and test without affecting your live systems.
-    </p>
-  </li>
-  <li class="usa-process-list__item">
-    <h3>Configure your application in the portal and start testing</h3>
-    <p>
-      Utilize our <a class="usa-link" href="#integration-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
-    </p>
-  </li>
-  <li class="usa-process-list__item">
-    <h3>Create a new application that's ready for production and make a request for your application to go live</h3>
-    <p>
-      Create a <a class="usa-link" href="{% link _pages/production.md %}#production-configuration-process">new application and make a request</a> to go live in production. We'll check your application to ensure it meets all administrative and technical requirements. Applications can only go live if you've completed an <a class="usa-link" href="{% link _pages/production.md %}#confirm-interagency-agreement-iaa">Inter-Agency Agreement</a>.
-    </p>
-  </li>
-</ol>
+<section class="margin-bottom-4">
+  <h2 id="how-to-integrate-login" class="padding-bottom-3 margin-top-0">How to integrate with Login.gov</h2>
+  <ol class="usa-process-list margin-bottom-4">
+    <li class="usa-process-list__item">
+      <h3>Register your application in our partner portal</h3>
+      <p>
+        First, create a team. Then, follow the steps to create an application in a sandbox environment where you can configure and test without affecting your live systems.
+      </p>
+    </li>
+    <li class="usa-process-list__item">
+      <h3>Configure your application in the portal and start testing</h3>
+      <p>
+        Utilize our <a class="usa-link" href="#integration-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
+      </p>
+    </li>
+    <li class="usa-process-list__item">
+      <h3>Create a new application that's ready for production and make a request for your application to go live</h3>
+      <p>
+        Create a <a class="usa-link" href="{% link _pages/production.md %}#production-configuration-process">new application and make a request</a> to go live in production. We'll check your application to ensure it meets all administrative and technical requirements. Applications can only go live if you've completed an <a class="usa-link" href="{% link _pages/production.md %}#confirm-interagency-agreement-iaa">Inter-Agency Agreement</a>.
+      </p>
+    </li>
+  </ol>
+</section>
 <hr class="text-primary-light border-solid measure-5 margin-x-0">
-<h2 id="integration-info-checklist">Integration information checklist</h2>
-<div id="home-register-checklist-accordion" class="usa-accordion usa-accordion__heading usa-accordion--bordered margin-bottom-3 maxw-tablet">
-  <button class="usa-accordion__button padding-y-1" aria-expanded="true" aria-controls="home-register-checklist">
-    <h3 class="font-body-md text-normal line-height-sans-1">Information you need to register your application</h3>
-  </button>
-  <div id="home-register-checklist" class="usa-accordion__content">
-    <ul class="usa-list list-style-checkbox">
-      <li>Inter-agency agreement application name</li>
-      <li>Public-face, friendly application name</li>
-      <li>Implementation protocols (SAML or Open ID Connect)</li>
-      <li>Service level as either Authentication only or Identity Verification</li>
-      <li>Data you need to keep and collect and other <a class="usa-link" href="{% link _pages/attributes.md %}">user attributes</a></li>
-      <li><a class="usa-link" href="{% link _pages/oidc/authorization.md %}">Authentication assurance</a> levels</li>
-      <li>Agency logo file</li>
-      <li>A public/private key pair and the <a class="usa-link" href="{% link _pages/testing.md %}#creating-a-public-certificate">public certificate</a> to validate your website and application’s authenticity</li>
-      <li>Content for the “sign up”, “sign in”, and “forgot password” language if you do not want to use the pre-selected options. Custom “Help” text is optional.</li>
-    </ul>
+<section class="margin-top-3 margin-bottom-4">
+  <h2 id="integration-info-checklist">Integration information checklist</h2>
+  <div id="home-register-checklist-accordion" class="usa-accordion usa-accordion__heading usa-accordion--bordered margin-bottom-3 maxw-tablet">
+    <button class="usa-accordion__button padding-y-1" aria-expanded="true" aria-controls="home-register-checklist">
+      <h3 class="font-body-md text-normal line-height-sans-1">Information you need to register your application</h3>
+    </button>
+    <div id="home-register-checklist" class="usa-accordion__content">
+      <ul class="usa-list list-style-checkbox">
+        <li>Inter-agency agreement application name</li>
+        <li>Public-face, friendly application name</li>
+        <li>Implementation protocols (SAML or Open ID Connect)</li>
+        <li>Service level as either Authentication only or Identity Verification</li>
+        <li>Data you need to keep and collect and other <a class="usa-link" href="{% link _pages/attributes.md %}">user attributes</a></li>
+        <li><a class="usa-link" href="{% link _pages/oidc/authorization.md %}">Authentication assurance</a> levels</li>
+        <li>Agency logo file</li>
+        <li>A public/private key pair and the <a class="usa-link" href="{% link _pages/testing.md %}#creating-a-public-certificate">public certificate</a> to validate your website and application’s authenticity</li>
+        <li>Content for the “sign up”, “sign in”, and “forgot password” language if you do not want to use the pre-selected options. Custom “Help” text is optional.</li>
+      </ul>
+    </div>
   </div>
-</div>
+</section>
 <p class="measure-5 margin-x-0">
   This website is for agency partners or developers. If you need technical support please contact <a class="usa-link" href="{% link _pages/support.md %}#contacting-partner-support">Partner Support</a> or view our <a class="usa-link" href="{% link _pages/support.md %}#frequently-asked-questions">FAQ</a> page. If you are not an agency partner or developer, please visit the <a class="usa-link" href="https://login.gov/help/">Login.gov Help Center</a> or <a class="usa-link" href="https://login.gov/contact/">contact us</a> for help signing in to your account or verifying your identity.
 </p>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -28,24 +28,36 @@ sidenav:
   <li class="usa-process-list__item">
     <h3>Configure your application in the portal and start testing</h3>
     <p>
-      Utilize our <a href="#integration-checklist" class="usa-link">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a href="{% link _pages/overview.md %}" class="usa-link">integrations guide</a> for more information.
+      Utilize our <a class="usa-link" href="#integration-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
     </p>
   </li>
   <li class="usa-process-list__item">
     <h3>Create a new application that's ready for production and make a request for your application to go live</h3>
     <p>
-      Create a <a href="{% link _pages/production.md %}#production-configuration-process" class="usa-link">new application and make a request</a> to go live in production. We'll check your application to ensure it meets all administrative and technical requirements. Applications can only go live if you've completed an <a href="{% link _pages/production.md %}#confirm-interagency-agreement-iaa" class="usa-link">Inter-Agency Agreement</a>.
+      Create a <a class="usa-link" href="{% link _pages/production.md %}#production-configuration-process">new application and make a request</a> to go live in production. We'll check your application to ensure it meets all administrative and technical requirements. Applications can only go live if you've completed an <a class="usa-link" href="{% link _pages/production.md %}#confirm-interagency-agreement-iaa">Inter-Agency Agreement</a>.
     </p>
   </li>
 </ol>
 <hr class="text-primary-light border-solid measure-5 margin-x-0">
 <h2 id="integration-info-checklist">Integration information checklist</h2>
-<section class="usa-section usa-prose padding-top-5">
-  <h2>Integration support for developers</h2>
-  <p class="measure-5 margin-x-0" markdown="1">
-    If you are with a government agency partner, check our [FAQ]({{ site.baseurl}}/support/#frequently-asked-questions) page for answers to the most common questions. If you need further technical assistance with an integration, you can [contact Partner Support]({{ site.baseurl}}/support/#contacting-partner-support).
-  </p>
-  <p class="measure-5 margin-x-0">
-    For help signing in or verifying your identity with Login.gov, please visit the <a href="https://login.gov/help/" class="usa-link">Login.gov Help Center</a> or <a href="https://login.gov/contact/" class="usa-link">contact us</a>.
-  </p>
-</section>
+<div id="home-register-checklist-accordion" class="usa-accordion usa-accordion__heading usa-accordion--bordered margin-bottom-3 maxw-tablet">
+  <button class="usa-accordion__button padding-y-1" aria-expanded="true" aria-controls="home-register-checklist">
+    <h3 class="font-body-md text-normal line-height-sans-1">Information you need to register your application</h3>
+  </button>
+  <div id="home-register-checklist" class="usa-accordion__content">
+    <ul class="usa-list list-style-checkbox">
+      <li>Inter-agency agreement application name</li>
+      <li>Public-face, friendly application name</li>
+      <li>Implementation protocols (SAML or Open ID Connect)</li>
+      <li>Service level as either Authentication only or Identity Verification</li>
+      <li>Data you need to keep and collect and other <a class="usa-link" href="{% link _pages/attributes.md %}">user attributes</a></li>
+      <li><a class="usa-link" href="{% link _pages/oidc/authorization.md %}">Authentication assurance</a> levels</li>
+      <li>Agency logo file</li>
+      <li>A public/private key pair and the <a class="usa-link" href="{% link _pages/testing.md %}#creating-a-public-certificate">public certificate</a> to validate your website and application’s authenticity</li>
+      <li>Content for the “sign up”, “sign in”, and “forgot password” language if you do not want to use the pre-selected options. Custom “Help” text is optional.</li>
+    </ul>
+  </div>
+</div>
+<p class="measure-5 margin-x-0">
+  This website is for agency partners or developers. If you need technical support please contact <a class="usa-link" href="{% link _pages/support.md %}#contacting-partner-support">Partner Support</a> or view our <a class="usa-link" href="{% link _pages/support.md %}#frequently-asked-questions">FAQ</a> page. If you are not an agency partner or developer, please visit the <a class="usa-link" href="https://login.gov/help/">Login.gov Help Center</a> or <a class="usa-link" href="https://login.gov/contact/">contact us</a> for help signing in to your account or verifying your identity.
+</p>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -28,7 +28,7 @@ sidenav:
     <li class="usa-process-list__item">
       <h3>Configure your application in the portal and start testing</h3>
       <p>
-        Utilize our <a class="usa-link" href="#integration-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
+        Utilize our <a class="usa-link" href="#integration-info-checklist">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a class="usa-link" href="{% link _pages/overview.md %}">integrations guide</a> for more information.
       </p>
     </li>
     <li class="usa-process-list__item">

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -3,53 +3,49 @@ title: Welcome to the Login.gov Developer Guide
 lead: >
   This developer guide contains everything you’ll need to integrate and deploy your application with Login.gov.
 permalink: /
-layout: home
+
+sidenav:
+  - text: How to integrate with Login.gov
+    href: '#how-to-integrate-login'
+  - text: Integration information checklist
+    href: '#integration-info-checklist'
 ---
 
-<div class="grid-container">
-  <div class="desktop:grid-col-9 desktop:grid-offset-2 mobile:grid-col-auto mobile:padding-2">
-    {% if site.temporary_alert %}
-    <section class="usa-section" markdown="1">  
-        {% include alert.html content=site.temporary_alert %}
-    </section>
-    {% endif %}
-    <h2 class='margin-top-4'>How to integrate with Login.gov</h2>
-    <ol class="usa-process-list usa-prose margin-bottom-4">
-      <li class="usa-process-list__item">
-        <p>
-          Your integration with Login.gov starts in the <a href="{{ site.baseurl }}/testing/#using-the-sandbox" class="usa-link">portal</a> where you can register your app.
-        </p>
-      </li>
-      <li class="usa-process-list__item">
-        <p>
-          Determine your application needs, like the level of proofing and <a href="{% link _pages/attributes.md %}" class="usa-link">user attributes</a> that will be requested.
-        </p>
-      </li>
-      <li class="usa-process-list__item">
-        <p>
-          Select between <a href="{% link _pages/oidc/getting-started.md %}" class="usa-link">Open ID Connect</a> (OIDC) or <a href="{% link _pages/saml/getting-started.md %}" class="usa-link">SAML</a> implementation protocols.
-        </p>
-      </li>
-      <li class="usa-process-list__item">
-        <p>
-          Configure your app in the portal and start <a href="{% link _pages/testing.md %}" class="usa-link">testing</a>! We have implementation guides and example apps to get you up and running quickly.
-        </p>
-      </li>
-      <li class="usa-process-list__item">
-        <p>
-          When you are ready to go live our team will help you <a href="{% link _pages/production.md %}" class="usa-link">promote the application to production</a>. We will check against our production checklist to ensure your application is ready for production from an administrative and technical standpoint.
-        </p>
-      </li>
-    </ol>
-    <hr class="text-primary-light border-solid measure-5 margin-x-0">
-    <section class="usa-section usa-prose padding-top-5">
-      <h2>Integration support for developers</h2>
-      <p class="measure-5 margin-x-0" markdown="1">
-        If you are with a government agency partner, check our [FAQ]({{ site.baseurl}}/support/#frequently-asked-questions) page for answers to the most common questions. If you need further technical assistance with an integration, you can [contact Partner Support]({{ site.baseurl}}/support/#contacting-partner-support).
-      </p>
-      <p class="measure-5 margin-x-0">
-        For help signing in or verifying your identity with Login.gov, please visit the <a href="https://login.gov/help/" class="usa-link">Login.gov Help Center</a> or <a href="https://login.gov/contact/" class="usa-link">contact us</a>.
-      </p>
-    </section>
-  </div>
-</div>
+{% if site.temporary_alert %}
+  <section class="usa-section" markdown="1">  
+      {% include alert.html content=site.temporary_alert %}
+  </section>
+{% endif %}
+<h2 id="how-to-integrate-login">How to integrate with Login.gov</h2>
+<br/>
+<ol class="usa-process-list usa-prose margin-bottom-4">
+  <li class="usa-process-list__item">
+    <h3>Register your application in our partner portal</h3>
+    <p>
+      First, create a team. Then, follow the steps to create an application in a sandbox environment where you can configure and test without affecting your live systems.
+    </p>
+  </li>
+  <li class="usa-process-list__item">
+    <h3>Configure your application in the portal and start testing</h3>
+    <p>
+      Utilize our <a href="#integration-checklist" class="usa-link">integration checklist</a> to verify you have all the necessary information for configuration. If you're not sure which options are right for your team, or if you're using a third-party application identity platform, please review our <a href="{% link _pages/overview.md %}" class="usa-link">integrations guide</a> for more information.
+    </p>
+  </li>
+  <li class="usa-process-list__item">
+    <h3>Create a new application that's ready for production and make a request for your application to go live</h3>
+    <p>
+      Create a <a href="{% link _pages/production.md %}#production-configuration-process" class="usa-link">new application and make a request</a> to go live in production. We'll check your application to ensure it meets all administrative and technical requirements. Applications can only go live if you've completed an <a href="{% link _pages/production.md %}#confirm-interagency-agreement-iaa" class="usa-link">Inter-Agency Agreement</a>.
+    </p>
+  </li>
+</ol>
+<hr class="text-primary-light border-solid measure-5 margin-x-0">
+<h2 id="integration-info-checklist">Integration information checklist</h2>
+<section class="usa-section usa-prose padding-top-5">
+  <h2>Integration support for developers</h2>
+  <p class="measure-5 margin-x-0" markdown="1">
+    If you are with a government agency partner, check our [FAQ]({{ site.baseurl}}/support/#frequently-asked-questions) page for answers to the most common questions. If you need further technical assistance with an integration, you can [contact Partner Support]({{ site.baseurl}}/support/#contacting-partner-support).
+  </p>
+  <p class="measure-5 margin-x-0">
+    For help signing in or verifying your identity with Login.gov, please visit the <a href="https://login.gov/help/" class="usa-link">Login.gov Help Center</a> or <a href="https://login.gov/contact/" class="usa-link">contact us</a>.
+  </p>
+</section>

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -51,8 +51,14 @@ main.usa-layout-docs {
 }
 
 
-.usa-prose > ul > .doc-sub-nav-item {
-  margin-bottom: 0px;
+.usa-prose {
+  & > ul > .doc-sub-nav-item {
+    margin-bottom: 0px;
+  }
+
+  li.usa-process-list__item {
+    @include u-padding-bottom(3);
+  }
 }
 
 .code-button {

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -174,6 +174,17 @@ button.code-button:hover {
   display: inline;
 }
 
+.list-style-checkbox {
+  & li {
+    padding-left: 0.5em;
+
+    &::marker {
+      font-size: 1.2em;
+      content: '☐';
+    }
+  }
+}
+
 @media (min-width: 1024px) {
   .code-snippet-column {
     background-color: transparent;

--- a/assets/scss/main.css.scss
+++ b/assets/scss/main.css.scss
@@ -182,11 +182,16 @@ button.code-button:hover {
 
 .list-style-checkbox {
   & li {
+    position: relative;
+    list-style-type: none;
     padding-left: 0.5em;
 
-    &::marker {
-      font-size: 1.2em;
+    &:before {
       content: '☐';
+      position: absolute;
+      left: -0.85em;
+      top: -0.4ex;
+      font-size: 1.2em;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001669",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
-      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
+      "version": "1.0.30001734",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6345,9 +6345,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001669",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
-      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w=="
+      "version": "1.0.30001734",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A=="
     },
     "chalk": {
       "version": "4.1.2",


### PR DESCRIPTION
# Ticket
[Portal #130 Implement UI for Partner Checklist in Dev Docs: How to  get to PROD](https://gitlab.login.gov/lg-teams/FIE/partner-portal-prod-edition/-/issues/130)

## Description:
Implement Partner Integration checklist in Dev Docs to match UI on the Partner Portal. This includes some copy changes, and the addition of a side nav to the page.

<details><summary>Old page</summary>
<img width="626" height="567" alt="Screenshot 2025-08-13 at 4 09 49 PM" src="https://github.com/user-attachments/assets/a961ab60-bb02-48db-b2f8-acd408fc6e47" />
</details>

<details><summary>New page</summary>
<img width="545" height="811" alt="Screenshot 2025-08-13 at 4 08 59 PM" src="https://github.com/user-attachments/assets/be98c417-d2ee-4fd1-8aca-7b0ef796c47c" />
</details>

## How to test:
Visit `/`, the home page of the dev docs. Compare to the [Figma handoff doc](https://figma-gov.com/design/qCIKMIaf5G0LdurkAQWYeo/%E2%9C%85--GL-129--Create-UI-for-Partner-Checklist_-How-to-get-to-PROD?node-id=85-256&t=vnTzCi45YwTMcvmU-0)