### PR TITLE
Consolidate release notes headers

### DIFF
--- a/_pages/release-notes.md
+++ b/_pages/release-notes.md
@@ -1,7 +1,7 @@
 ---
-title: Release Notes
+title: Partner Portal Release Notes
 ---
-<div class="usa-intro"> Login.gov Partner Portal Release Notes</div>
+
 <p>Below you can find notes regarding features added and bugs addressed in the portal. Click the plus icon to view the notes for a specific release. Releases are ordered with most recent at the top.<p>
 
 <dl class="usa-accordion usa-accordion--bordered">


### PR DESCRIPTION
I spoke with Nick about how to handle the headers in the Release Notes page and he suggested we could just have 1 header since they were a little redundant anyway. 